### PR TITLE
feat: add CSV file selection and print drag data in simulation

### DIFF
--- a/src/main/java/com/waterloorocketry/dragoverride/DragOverride.java
+++ b/src/main/java/com/waterloorocketry/dragoverride/DragOverride.java
@@ -9,11 +9,8 @@ import com.waterloorocketry.dragoverride.simulated.AeroData;
 import com.waterloorocketry.dragoverride.simulated.ReadCSV;
 import com.waterloorocketry.dragoverride.util.LazyMap;
 import info.openrocket.core.simulation.SimulationConditions;
-import info.openrocket.core.simulation.SimulationStatus;
 import info.openrocket.core.simulation.exception.SimulationException;
 import info.openrocket.core.simulation.extension.AbstractSimulationExtension;
-import info.openrocket.core.simulation.listeners.AbstractSimulationListener;
-import info.openrocket.core.util.Coordinate;
 
 
 public class DragOverride extends AbstractSimulationExtension {
@@ -25,14 +22,11 @@ public class DragOverride extends AbstractSimulationExtension {
 
         ReadCSV readCSV = new ReadCSV();
         LazyMap<Double, AeroData, AeroData> dragData = readCSV.readCSV(this.getCSVFile());
+        System.out.println(dragData.get(0.1).toString());
     }
 
     public String getName() {
         return "DragOverride";
-    }
-
-    public String getId() {
-        return "com.waterloorocketry.dragoverride";
     }
 
     @Override

--- a/src/main/java/com/waterloorocketry/dragoverride/DragOverrideConfigurator.java
+++ b/src/main/java/com/waterloorocketry/dragoverride/DragOverrideConfigurator.java
@@ -6,6 +6,8 @@ import info.openrocket.swing.simulation.extension.AbstractSwingSimulationExtensi
 
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
+import java.awt.*;
+import java.io.File;
 
 @Plugin
 public class DragOverrideConfigurator extends AbstractSwingSimulationExtensionConfigurator<DragOverride> {
@@ -14,21 +16,50 @@ public class DragOverrideConfigurator extends AbstractSwingSimulationExtensionCo
         super(DragOverride.class);
     }
 
+    @Override
     protected JComponent getConfigurationComponent(DragOverride extension, Simulation simulation, JPanel panel) {
-        panel.add(new JLabel("Reference .csv file:"));
+        // Set panel layout and padding
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBorder(BorderFactory.createEmptyBorder(15, 15, 15, 15)); // Padding (top, left, bottom, right)
+        panel.setPreferredSize(new Dimension(400, 150)); // Set default size
 
-        JButton selectFile = new JButton("Select File");
+        // Label for CSV file selection
+        JLabel fileLabel = new JLabel("Reference .csv file:");
+        fileLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        // Label for displaying selected file path
+        String csvPath = (extension.getCSVFile() != null) ? extension.getCSVFile() : "No file selected";
+        JLabel selectedFileLabel = new JLabel(csvPath);
+        selectedFileLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        // Button for file selection
+        JButton selectFileButton = new JButton("Select File");
+        selectFileButton.setAlignmentX(Component.LEFT_ALIGNMENT);
+
         JFileChooser fileChooser = new JFileChooser();
-        // prevents directories from being selected
         fileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-        // shows only csv files
         fileChooser.setFileFilter(new FileNameExtensionFilter("CSV Files (*.csv)", "csv"));
 
-        selectFile.addActionListener(event -> {
-            fileChooser.showOpenDialog(panel);
+        selectFileButton.addActionListener(event -> {
+            int returnValue = fileChooser.showOpenDialog(panel);
+
+            if (returnValue == JFileChooser.APPROVE_OPTION) {
+                File selectedFile = fileChooser.getSelectedFile();
+                if (selectedFile != null) {
+                    String selectedPath = selectedFile.getAbsolutePath();
+                    extension.setCSVFile(selectedPath);
+                    selectedFileLabel.setText(selectedPath);
+                }
+            }
         });
 
-        panel.add(selectFile);
+        // Add components to panel with spacing
+        panel.add(fileLabel);
+        panel.add(Box.createRigidArea(new Dimension(0, 10))); // Adds spacing
+        panel.add(selectedFileLabel);
+        panel.add(Box.createRigidArea(new Dimension(0, 10)));
+        panel.add(selectFileButton);
+
         return panel;
     }
 }

--- a/src/main/java/com/waterloorocketry/dragoverride/DragOverrideSimulationListener.java
+++ b/src/main/java/com/waterloorocketry/dragoverride/DragOverrideSimulationListener.java
@@ -22,7 +22,7 @@ public class DragOverrideSimulationListener extends AbstractSimulationListener {
     @Override
     public AerodynamicForces postAerodynamicCalculation(SimulationStatus status, AerodynamicForces forces) throws SimulationException {
         final double velocityZ = status.getRocketVelocity().z;
-        System.out.println("Velocity: " + velocityZ);
+//        System.out.println("Velocity: " + velocityZ);
         return forces;
     }
 }


### PR DESCRIPTION
This pull request includes various changes to the `DragOverride` plugin for OpenRocket, focusing on code cleanup, debugging, and UI improvements. Below is a summary of the most important changes:

### Code Cleanup:
* Removed unused imports from `DragOverride.java` to tidy up the code.
* Removed the `getId` method from `DragOverride.java` as it was not being used.

### Debugging:
* Added a debug print statement in `initialize` method of `DragOverride.java` to print the drag data for verification.
* Commented out a debug print statement in `DragOverrideSimulationListener.java` to reduce console clutter.

### UI Improvements:
* Enhanced the configuration panel in `DragOverrideConfigurator.java` by setting layout, padding, and adding a label to display the selected CSV file path.