### PR TITLE
remove openrocketry submodule to integrate with monte-carlo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "openrocket"]
-	path = openrocket
-	url = https://github.com/openrocket/openrocket.git

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ version '0.1'
 
 repositories {
     flatDir {
-        dirs 'openrocket/build/libs' // Point to the submodule's output
+        dirs '../../openrocket/build/libs', './' // Point to integrated or-monte-carlo jar or standalone jar
     }
     // Use Maven Central for resolving dependencies.
     mavenCentral()
@@ -41,21 +41,7 @@ java {
     }
 }
 
-task buildOpenRocket(type: Exec) {
-    workingDir 'openrocket'
-
-    // Detect OS and set the appropriate gradlew command
-    def isWindows = System.getProperty('os.name').toLowerCase().contains('windows')
-    commandLine isWindows ? 'gradlew.bat' : './gradlew', 'build'
-}
-
-// Make sure the submodule builds before the main build
-tasks.named('build') {
-    dependsOn buildOpenRocket
-}
-
 tasks.register('run', JavaExec) {
-    dependsOn buildOpenRocket
     mainClass = 'info.openrocket.swing.startup.OpenRocket'
     classpath = sourceSets.main.runtimeClasspath
     systemProperty 'java.library.path', 'build/natives/lib'


### PR DESCRIPTION
To integrate with or-monte-carlo, we will use a shared submodule so as not to unnecessarily clone multiple of the same repo (its a big repo)
Future development on the standalone plugin will need to download the jar file directly and place in root